### PR TITLE
Track current development dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,17 +7,28 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
-    versioning-strategy: lockfile-only
+    versioning-strategy: increase-if-necessary
     open-pull-requests-limit: 5
     groups:
-      routine-updates:
+      development-routine:
+        dependency-type: development
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
+      production-resolutions:
+        dependency-type: production
         patterns:
           - '*'
         update-types:
           - minor
           - patch
     ignore:
-      - dependency-name: '*'
+      - dependency-name: jest-matcher-utils
+        update-types:
+          - version-update:semver-major
+      - dependency-name: openai
         update-types:
           - version-update:semver-major
 


### PR DESCRIPTION
## Summary
- allow Dependabot to propose development dependency majors as individual PRs
- group routine development and production resolution updates separately
- preserve the published runtime major lines for `openai` and `jest-matcher-utils`
- retain the seven-day release cooldown

## Validation
- Dependabot YAML parse
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `npm run test:coverage` (17 tests)
- CodeRabbit review: 0 findings